### PR TITLE
Bump version number to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name='itk-ioomezarrngff',
-    version='0.1.1',
+    version='0.1.2',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],


### PR DESCRIPTION
We should make another patch release before continuing development. https://github.com/google/tensorstore/issues/57 will likely require dropping support for Python 3.7, so this will be the last release which supports it.