### PR TITLE
ENH: Exception fixes and bounds checking

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -110,7 +110,7 @@ jobs:
           "note: prefix with the address-of operator to silence this warning"
           "warning C4722: 'riegeli::internal::UnreachableStream::~UnreachableStream': destructor never returns, potential memory leak"
           "warning C4722: 'riegeli::internal::CheckFailed::~CheckFailed': destructor never returns, potential memory leak"
-          "_deps[/\\].+-src[/\\]"  # disable all warnings from external projects
+          "_deps[/\\\\].+-src[/\\\\]"  # disable all warnings from external projects
           # the following warnings escape the above filter
           "warning: Import validate/validate.proto is unused"
           "warning:.+__builtin___memcpy_chk"

--- a/src/itkOMEZarrNGFFImageIO.cxx
+++ b/src/itkOMEZarrNGFFImageIO.cxx
@@ -321,9 +321,9 @@ addCoordinateTransformations(OMEZarrNGFFImageIO * io, nlohmann::json ct)
 {
   itkAssertOrThrowMacro(ct.is_array(), "Failed to parse coordinate transforms");
   itkAssertOrThrowMacro(ct.size() >= 1, "Expected at least one coordinate transform");
-  itkAssertOrThrowMacro(
-    ct[0].at("type") == "scale",
-    ("Expected first transform to be \"scale\" but found " + ct[0].at("type"))); // first transformation must be scale
+  itkAssertOrThrowMacro(ct[0].at("type") == "scale",
+                        ("Expected first transform to be \"scale\" but found " +
+                         std::string(ct[0].at("type")))); // first transformation must be scale
 
   nlohmann::json s = ct[0].at("scale");
   itkAssertOrThrowMacro(s.is_array(), "Failed to parse scale transform");
@@ -341,7 +341,7 @@ addCoordinateTransformations(OMEZarrNGFFImageIO * io, nlohmann::json ct)
   {
     itkAssertOrThrowMacro(ct[1].at("type") == "translation",
                           ("Expected second transform to be \"translation\" but found " +
-                           ct[1].at("type"))); // first transformation must be scale
+                           std::string(ct[1].at("type")))); // first transformation must be scale
     nlohmann::json tr = ct[1].at("translation");
     itkAssertOrThrowMacro(tr.is_array(), "Failed to parse translation transform");
     dim = tr.size();
@@ -404,11 +404,11 @@ OMEZarrNGFFImageIO::ReadImageInformation()
     addCoordinateTransformations(this, json.at("coordinateTransformations")); // dataset-level scaling
   }
   json = json.at("datasets");
-  if (this->GetDatasetIndex() > json.size())
+  if (this->GetDatasetIndex() >= json.size())
   {
     itkExceptionMacro(<< "Requested DatasetIndex of " << this->GetDatasetIndex()
-                      << " is greater than number of datasets (" << json.size() << ") which exist in OME-NGFF store '"
-                      << this->GetFileName() << "'");
+                      << " is out of range for the number of datasets (" << json.size()
+                      << ") which exist in OME-NGFF store '" << this->GetFileName() << "'");
   }
 
   json = json[this->GetDatasetIndex()];


### PR DESCRIPTION
Changes:
- Replace `assert` messages with `itkAssertOrThrowMacro` to emit `itk::ExceptionObject`s on failure, which are handled in ITKOMEZarrNGFF unit tests and provide line references with error output in ITK Python.

- Clarifies file read errors. Previous messages indicated JSON failure rather than missing file
Previous behavior:
```py
RuntimeError: [json.exception.out_of_range.403] key 'multiscales' not found
```
Updated behavior:
```py
RuntimeError: D:\repos\ITKIOOMEZarrNGFF\src\itkOMEZarrNGFFImageIO.cxx:374:
ITK ERROR: Failed to read from C:/bad/path/.zgroup
```

- Resolves handling where requested index is equal to the size of available datasets and thus out of bounds.
Previous behavior:
```py
RuntimeError: D:\a\im\src\itkOMEZarrNGFFImageIO.cxx:395:
ITK ERROR: OMEZarrNGFFImageIO(000001A91BDBD060): OME-NGFF v0.4 requires `coordinateTransformations` for each resolution level.
```
Updated behavior:
```py
ITK ERROR: OMEZarrNGFFImageIO(0000015D06528500): Requested DatasetIndex of 4 is greater than number of datasets (4) which exist in OME-NGFF store
```