### PR TITLE
BUG: Python itk-io package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.4rc01'
+        r'itk-io>=5.4rc1'
     ]
     )


### PR DESCRIPTION
itk-io is a more constrained dependency.

Python packages do not have a preceding 0 in the RC's: rc1 vs rc01.