### PR TITLE
STYLE: Output test data into CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,20 +14,20 @@ CreateTestDriver(IOOMEZarrNGFF "${IOOMEZarrNGFF-Test_LIBRARIES}" "${IOOMEZarrNGF
 #   COMMAND IOOMEZarrNGFFTestDriver
 #     --compare
 #       DATA{Baseline/SmallSpectra.nrrd}
-#       ${ITK_TEST_OUTPUT_DIR}/SmallSpectra.nrrd
+#       ${CMAKE_CURRENT_BINARY_DIR}/SmallSpectra.nrrd
 #     itkOMEZarrNGFFImageIOTest
 #       DATA{Input/SmallSpectra.zip}
-#       ${ITK_TEST_OUTPUT_DIR}/SmallSpectra.nrrd
+#       ${CMAKE_CURRENT_BINARY_DIR}/SmallSpectra.nrrd
 #   )
 # 
 # itk_add_test(NAME IOOMEZarrNGFF_SmallSpectra_zip
 #   COMMAND IOOMEZarrNGFFTestDriver
 #     --compare
 #       DATA{Input/SmallSpectra.zip}
-#       ${ITK_TEST_OUTPUT_DIR}/SmallSpectra.zip
+#       ${CMAKE_CURRENT_BINARY_DIR}/SmallSpectra.zip
 #     itkOMEZarrNGFFImageIOTest
 #       DATA{Baseline/SmallSpectra.nrrd}
-#       ${ITK_TEST_OUTPUT_DIR}/SmallSpectra.zip
+#       ${CMAKE_CURRENT_BINARY_DIR}/SmallSpectra.zip
 #   )
 
 # 2D test with identity metadata
@@ -35,10 +35,10 @@ itk_add_test(NAME IOOMEZarrNGFF_cthead1_mha
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Input/cthead1.mha}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.zarr
     itkOMEZarrNGFFImageIOTest
       DATA{Input/cthead1.mha}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.zarr
   )
 
 # 3D test image with non-identity spacing
@@ -46,10 +46,10 @@ itk_add_test(NAME IOOMEZarrNGFF_DzZ_T1seg
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Input/DzZ_Seeds.seg.nrrd}
-      ${ITK_TEST_OUTPUT_DIR}/DzZ_T1seg.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/DzZ_T1seg.zarr
     itkOMEZarrNGFFImageIOTest
       DATA{Input/DzZ_Seeds.seg.nrrd}
-      ${ITK_TEST_OUTPUT_DIR}/DzZ_T1seg.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/DzZ_T1seg.zarr
   )
 
 # 3D test image with non-identity origin and spacing
@@ -57,40 +57,40 @@ itk_add_test(NAME IOOMEZarrNGFF_OriginSpacing
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Input/PV6.0_FLASH_FLOAT32.mha}
-      ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_FLOAT32.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/PV6.0_FLASH_FLOAT32.zarr
     itkOMEZarrNGFFImageIOTest
       DATA{Input/PV6.0_FLASH_FLOAT32.mha}
-      ${ITK_TEST_OUTPUT_DIR}/PV6.0_FLASH_FLOAT32.zarr
+      ${CMAKE_CURRENT_BINARY_DIR}/PV6.0_FLASH_FLOAT32.zarr
   )
 
 itk_add_test(NAME IOOMEZarrNGFF_cthead1_zipWrite
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Input/cthead1.mha}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.zarr.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.zarr.zip
     itkOMEZarrNGFFImageIOTest
       DATA{Input/cthead1.mha}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.zarr.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.zarr.zip
   )
 
 itk_add_test(NAME IOOMEZarrNGFF_cthead1_zipRead
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Baseline/cthead1.zarr.zip}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.mha
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.mha
     itkOMEZarrNGFFImageIOTest
       DATA{Baseline/cthead1.zarr.zip}
-      ${ITK_TEST_OUTPUT_DIR}/cthead1.mha
+      ${CMAKE_CURRENT_BINARY_DIR}/cthead1.mha
   )
 
 itk_add_test(NAME IOOMEZarrNGFF_inMemory_zip
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Baseline/cthead1.zarr.zip}
-      ${ITK_TEST_OUTPUT_DIR}/memory.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/memory.zip
     itkOMEZarrNGFFInMemoryTest
       DATA{Baseline/cthead1.zarr.zip}
-      ${ITK_TEST_OUTPUT_DIR}/memory.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/memory.zip
   )
   
 # 2D test with identity metadata
@@ -98,11 +98,11 @@ itk_add_test(NAME IOOMEZarrNGFF_readSubregion
 COMMAND IOOMEZarrNGFFTestDriver
   --compare
     DATA{Baseline/cthead1Subregion.mha}
-    ${ITK_TEST_OUTPUT_DIR}/cthead1Subregion.mha
+    ${CMAKE_CURRENT_BINARY_DIR}/cthead1Subregion.mha
   itkOMEZarrNGFFReadSubregionTest
     DATA{Input/cthead1.mha}
-    ${ITK_TEST_OUTPUT_DIR}/cthead1.zarr
-    ${ITK_TEST_OUTPUT_DIR}/cthead1Subregion.mha
+    ${CMAKE_CURRENT_BINARY_DIR}/cthead1.zarr
+    ${CMAKE_CURRENT_BINARY_DIR}/cthead1Subregion.mha
 )
 
 # HTTP test with encoded test cases


### PR DESCRIPTION
This makes the files easier to find. Also, I am wondering if the intermittent failing tests in CI are due to directory existence / permissions.

> terminate called after throwing an instance of 'std::runtime_error'
196
  what():  Could not open /home/runner/work/ITKIOOMEZarrNGFF/build/Testing/Temporary/IOOMEZarrNGFF/cthead1.zarr.zip