### PR TITLE
ENH: Add checks to validate in-memory I/O behavior

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -6,7 +6,7 @@ env:
   itk-git-tag: "v5.4rc01"
   itk-wheel-tag: "v5.4rc01"
   ITKPythonPackage-git-tag: "5ad02309321621cdc7269b9b68a35013c912271c"
-  ctest-options: "-E IOOMEZarrNGFF_inMemory_zip"
+  ctest-options: ""
 
 jobs:
   build-test-cxx:


### PR DESCRIPTION
Followup to formalize extra test steps developed for in-memory issue investigation in #36.

Validate behavior:
    - ITK image buffer is a deep copy of the input memory buffer
    - Memory buffer remains valid after read
    - Write operation creates a new in-memory buffer
    - Write operation updates an existing BufferInfo descriptor
    - Output file is written and can be read back in

Re-enables in-memory test in CI.