### PR TITLE
BUG: close memory test file ofstream after writing

### DIFF
--- a/test/itkOMEZarrNGFFInMemoryTest.cxx
+++ b/test/itkOMEZarrNGFFInMemoryTest.cxx
@@ -85,6 +85,7 @@ doTest(const char * inputFileName, const char * outputFileName)
 
   std::ofstream oFile(outputFileName, std::ios::binary);
   oFile.write(bufferInfo.pointer, bufferInfo.size);
+  oFile.close();
   free(bufferInfo.pointer);
 
   std::cout << "Test finished" << std::endl;


### PR DESCRIPTION
Explicitly close the files, flush to disk.