### PR TITLE
Disable failing zip test and bump version

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -6,6 +6,7 @@ env:
   itk-git-tag: "v5.4rc01"
   itk-wheel-tag: "v5.4rc01"
   ITKPythonPackage-git-tag: "5ad02309321621cdc7269b9b68a35013c912271c"
+  ctest-options: "-E IOOMEZarrNGFF_inMemory_zip"
 
 jobs:
   build-test-cxx:
@@ -137,13 +138,13 @@ jobs:
     - name: Build and test
       if: matrix.os != 'windows-2022'
       run: |
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ env.ctest-options }}
 
     - name: Build and test
       if: matrix.os == 'windows-2022'
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ env.ctest-options }}
       shell: cmd
 
   build-linux-py:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
 
 setup(
     name='itk-ioomezarrngff',
-    version='0.1.4',
+    version='0.1.6',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],


### PR DESCRIPTION
Disable "IOOMEZarrNGFF_inMemory_zip" test which sometimes writes a
  corrupted archive on Linux.

  "zip" tensorstore driver will be investigated independently in the
  InsightSoftwareConsortium Tensorstore fork and enabled when "zip" write
  on Linux is supported again.

  https://github.com/InsightSoftwareConsortium/ITKIOOMEZarrNGFF/issues/36

Also bumps to v0.1.6 for subsequent tag and upload to PyPI.