### PR TITLE
BUG: Fix duplicate test output filename

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,10 +124,10 @@ itk_add_test(
   COMMAND IOOMEZarrNGFFTestDriver
     --compare
       DATA{Baseline/simple_tyx_t1.mha}
-      ${ITK_TEST_OUTPUT_DIR}/simple_tyx_t0.mha
+      ${ITK_TEST_OUTPUT_DIR}/simple_tyx_t1.mha
     itkOMEZarrNGFFReadSliceTest
       DATA{Input/simple_tyx.zarr.zip}
-      ${ITK_TEST_OUTPUT_DIR}/simple_tyx_t0.mha
+      ${ITK_TEST_OUTPUT_DIR}/simple_tyx_t1.mha
       2
       1
 )


### PR DESCRIPTION
Fix duplicate test output filename: tests
`IOOMEZarrNGFF_readTimeIndex0` and `IOOMEZarrNGFF_readTimeIndex1` were using the same outputfilenames, and some CI builds were failing probably because they were trying to read/write to the same location.

Fixes:
```
Exception detected while reading
ITKIOOMEZarrNGFF/build/ExternalData/test/Baseline/simple_tyx_t0.mha :
  Could not create IO object for reading file
ITKIOOMEZarrNGFF/build/Testing/Temporary/IOOMEZarrNGFF/simple_tyx_t0.mha
```

raised for example at:
https://github.com/InsightSoftwareConsortium/ITKIOOMEZarrNGFF/actions/runs/9648607798/job/26615199448#step:15:223