### PR TITLE
Replace READ_ELEMENT_IF with variadic template, move functions into unnamed namespace

### DIFF
--- a/src/itkOMEZarrNGFFImageIO.cxx
+++ b/src/itkOMEZarrNGFFImageIO.cxx
@@ -637,7 +637,6 @@ OMEZarrNGFFImageIO::Read(void * buffer)
   if (false)
   {
   }
-  READ_ELEMENT_IF(float)
   READ_ELEMENT_IF(int8_t)
   READ_ELEMENT_IF(uint8_t)
   READ_ELEMENT_IF(int16_t)


### PR DESCRIPTION
Just some style improvements:
- Replaced the original `READ_ELEMENT_IF` macro with a variadic template, `TryToReadFromStore`.
- Moved the functions `tensorstoreToITKComponentType` and `itkToTensorstoreComponentType` into an unnamed namespace
