### PR TITLE
STYLE: Replace thread_local variables with m_TensorStoreData data member

### DIFF
--- a/include/itkOMEZarrNGFFImageIO.h
+++ b/include/itkOMEZarrNGFFImageIO.h
@@ -22,6 +22,7 @@
 
 
 #include <fstream>
+#include <memory> // For unique_ptr.
 #include <string>
 #include <vector>
 #include "itkImageIOBase.h"
@@ -182,7 +183,7 @@ public:
 
 protected:
   OMEZarrNGFFImageIO();
-  ~OMEZarrNGFFImageIO() override = default;
+  ~OMEZarrNGFFImageIO() override;
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
@@ -246,6 +247,9 @@ private:
   char                      m_EmptyZip[m_EmptyZipSize] = "PK\x05\x06"; // the rest is filled with zeroes
   const BufferInfo          m_EmptyZipBufferInfo{ m_EmptyZip, m_EmptyZipSize };
   const std::string         m_EmptyZipFileName = MakeMemoryFileName(m_EmptyZipBufferInfo);
+
+  struct TensorStoreData;
+  const std::unique_ptr<TensorStoreData> m_TensorStoreData;
 };
 } // end namespace itk
 


### PR DESCRIPTION
It appears preferable that multiple OMEZarrNGFFImageIO instances do not share their TensorStore context and store. With this commit, each OMEZarrNGFFImageIO instance will have its own context and store, stored in its `m_TensorStoreData` data member.

The `m_TensorStoreData` data member hides the TensorStore data from the interface, as it is a pointer to a forward-declared struct, similar to the "Pimpl" idiom.